### PR TITLE
Render tiles of map as hexagons

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,26 +1,12 @@
 import tkinter as tk
-import math
-
-def draw_hexagon(canvas, x, y, size, color):
-    angle = math.pi / 3
-    points = [
-        (x + size * math.cos(i * angle), y + size * math.sin(i * angle)) for i in range(6)
-    ]
-    canvas.create_polygon(points, outline='black', fill=color, width=2)
-
-def create_hexagon_tiling(canvas, rows, cols, size):
-    for row in range(rows):
-        for col in range(cols):
-            x = col * size * 1.5
-            y = row * size * math.sqrt(3) + (col % 2) * size * math.sqrt(3) / 2
-            draw_hexagon(canvas, x, y, size, 'white')
+from src.map import render_map
 
 root = tk.Tk()
-root.title("Hexagon Tiling")
+root.title("Dorfromantik")
 
 canvas = tk.Canvas(root, width=800, height=600)
 canvas.pack()
 
-create_hexagon_tiling(canvas, 10, 10, 30)
+render_map(canvas, 30)
 
 root.mainloop()

--- a/src/map.py
+++ b/src/map.py
@@ -1,3 +1,5 @@
+from src.tile import render_tile
+
 class Map:
     def __init__(self):
         self.tiles = {}
@@ -7,3 +9,8 @@ class Map:
 
     def remove_tile(self, position):
         self.tiles.remove(position)
+
+    def render_map(self, canvas, size):
+        for position, tile in self.tiles.items():
+            row, col = position
+            render_tile(canvas, row, col, size, tile)

--- a/src/tile.py
+++ b/src/tile.py
@@ -1,6 +1,19 @@
+from src.main import draw_hexagon
+import math
+
 class Tile:
     def __init__(self, edges):
         self.edges = edges
 
     def rotate(self):
         self.edges = self.edges[-1:] + self.edges[:-1]
+
+    def render_tile(self, canvas, row, col, size):
+        color = 'white'  # You can customize the color based on tile properties
+        x = col * size * 1.5
+        y = row * size * math.sqrt(3) + (col % 2) * size * math.sqrt(3) / 2
+        angle = math.pi / 3
+        points = [
+            (x + size * math.cos(i * angle), y + size * math.sin(i * angle)) for i in range(6)
+        ]
+        canvas.create_polygon(points, outline='black', fill=color, width=2)


### PR DESCRIPTION
Fixes #4

Add rendering functionality to display map tiles as hexagons.

* **src/main.py**
  - Import `render_map` function from `src/map.py`.
  - Call `render_map` function to render the game map as a grid of hexagons.
  - Remove `draw_hexagon` and `create_hexagon_tiling` functions.

* **src/map.py**
  - Add `render_map` function to render tiles as hexagons using `render_tile` function from `src/tile.py`.

* **src/tile.py**
  - Add `render_tile` function to render individual tiles as hexagons using `draw_hexagon` function from `src/main.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Lunkle/dorfromantik-solver/issues/4?shareId=bed04542-dcee-4c6d-a27b-c03664577455).